### PR TITLE
Localizer: no unknown language error in production

### DIFF
--- a/src/types/Localizer/Localizer.ts
+++ b/src/types/Localizer/Localizer.ts
@@ -464,7 +464,11 @@ export class Localizer {
 			const langName = langs[i];
 			const langFile = languagesTree[langName];
 
-			for (const key of await this.extendLanguage(langName, langFile)) {
+			const langKeys = await this.extendLanguage(langName, langFile);
+
+			if (!langKeys) { continue; }
+
+			for (const key of langKeys) {
 				if (!importedKeys.includes(key)) {
 					importedKeys.push(key);
 				}

--- a/src/types/Localizer/Localizer.ts
+++ b/src/types/Localizer/Localizer.ts
@@ -366,10 +366,20 @@ export class Localizer {
 		const keysAssignation = this._keysAssignation;
 		const importedKeys: string[] = [];
 		const langMap = this._langsMap[langName];
-		const sourceLanguage =
-			langName !== this._sourceLang ? this._langsMap[this._sourceLang] : undefined;
 
-		if (!langMap) { throw new Error(`Language "${langName}" is not loaded yet`); }
+		const sourceLanguage = langName !== this._sourceLang
+			? this._langsMap[this._sourceLang]
+			: undefined;
+
+		if (!langMap) { 
+			if (process.env["NODE_ENV"] !== "production") {
+				throw new Error(`Language "${langName}" is not loaded yet`);
+			}
+
+			this._log("warn_trace", `Language "${langName}" is not loaded, skipping...`);
+
+			return;
+		}
 
 		if (typeof langFile !== "object" || Array.isArray(langFile)) {
 			langFile = await this._loader.loadStringsMap(langFile);

--- a/src/types/Localizer/Localizer.ts
+++ b/src/types/Localizer/Localizer.ts
@@ -572,7 +572,7 @@ export class Localizer {
 	) {
 		const str = this.getString(lang, key, fallback);
 
-		return <string> this.formatString(lang, str, variables);
+		return this.formatString(lang, str, variables);
 	}
 
 	public formatString(


### PR DESCRIPTION
When extending an unknown language, do not throw an error if process is running in the production environment. This allows running modules that do not check languages list on extending (8Ball, for example) and should not cause any harm to the process and flow.